### PR TITLE
Added support for css selector lists, e.g. ".component1, .component2,…

### DIFF
--- a/ie11CustomProperties.js
+++ b/ie11CustomProperties.js
@@ -240,15 +240,23 @@
 		});
 	}
 	function addGetterElement(el, properties, selector) {
+		var selectorIndex;
 		el.setAttribute('iecp-needed', true);
 		if (!el.ieCPSelectors) el.ieCPSelectors = {};
 		for (var i = 0, prop; prop = properties[i++];) {
-			const parts = selector.trim().split('::');
-			if (!el.ieCPSelectors[prop]) el.ieCPSelectors[prop] = [];
-			el.ieCPSelectors[prop].push({
-				selector: parts[0],
-				pseudo: parts[1] ? '::'+parts[1] : '',
-			});
+			// split ".component, .component-variation" into separate selectors to allow proper overriding
+			const selectorParts = selector.split(',');
+			for (selectorIndex = 0; selectorIndex < selectorParts.length; selectorIndex++) {
+				const parts = selectorParts[selectorIndex].trim().split('::');
+				if (!el.ieCPSelectors[prop]) {
+					el.ieCPSelectors[prop] = [];
+				}
+
+				el.ieCPSelectors[prop].push({
+					selector: parts[0],
+					pseudo: parts[1] ? '::' + parts[1] : ''
+				});
+			}
 		}
 	}
 	function addSettersSelector(selector, propVals) {


### PR DESCRIPTION
… .component2-variation {}" to allow proper overriding of a selector that's not the last selector in the list.

Examples:
Before: .component1, .component2, .component2-variation.iecp-u123 {}
After: .component1.iecp-u123 {} .component2.iecp-u123 {} .component2-variation.iecp-u123 {}

Before: .mylink:link, .mylink:visited.iecp-123 {}
After: .mylink:link.iecp-123 {} .mylink:visited.iecp-123 {}