### PR TITLE
Fix "Use before declaration"

### DIFF
--- a/ie11CustomProperties.js
+++ b/ie11CustomProperties.js
@@ -316,9 +316,9 @@
 			var parts = selector.split(':'+pseudo);
 			if (parts.length > 1) {
 				var ending = parts[1].match(/^[^\s]*/); // ending elementpart of selector (used for not(:active))
-				let selector = unPseudo(parts[0]+ending);
+				let sel = unPseudo(parts[0]+ending);
 				const listeners = pseudos[pseudo];
-				c1.onElement(selector, function (el) {
+				c1.onElement(sel, function (el) {
 					el.addEventListener(listeners.on, drawTreeEvent);
 					el.addEventListener(listeners.off, drawTreeEvent);
 				});


### PR DESCRIPTION
I'm getting this error in IE11:

```
ReferenceError Use before declaration 
    ie11CustomProperties.js:290:3 selectorAddPseudoListeners
    ie11CustomProperties.js:236:3 addGettersSelector
    ie11CustomProperties.js:220:23 activateStyleElement
    ie11CustomProperties.js:139:4 Anonymous function
    ie11CustomProperties.js:531:5 request.onload
```

It's coming from this line:

```javascript
selector = selector.split(',')[0];
```

I noticed that `selector` variable is not only used as an argument of `selectorAddPseudoListeners()` but it's also declared again 5 lines later:

```javascript
let selector = unPseudo(parts[0]+ending);
```

I believe that's the reason why IE11 is freaking out. Even though `let` should be block-scoped, IE11 clearly doesn't like it. In any case, shadowing variable declarations in general is not a good idea, so this small PR just changes the variable name to something else so it doesn't clash with the upper scope `selector`.