### PR TITLE
Fix issue with multiple SVGs on same page

### DIFF
--- a/ie11CustomProperties.js
+++ b/ie11CustomProperties.js
@@ -406,21 +406,21 @@
 		for (var i = 0, el; el = els[i++];) drawElement(el); // tree
 	}
 	// draw queue
-	let drawQueue = {};
+	let drawQueue = new Set();
 	let collecting = false;
 	let drawing = false;
 	function drawElement(el){
-		drawQueue[el.uniqueNumber] = el;
+		drawQueue.add(el);
 		if (collecting) return;
 		collecting = true;
 		requestAnimationFrame(function(){
 			collecting = false;
 			drawing = true;
-			for (var nr in drawQueue) _drawElement(drawQueue[nr]);
+			drawQueue.forEach(_drawElement);
 			requestAnimationFrame(function(){ // mutationObserver will trigger delayed
 				drawing = false;
 			})
-			drawQueue = {};
+			drawQueue.clear();
 		})
 	}
 


### PR DESCRIPTION
**Issue**
If there are multiple SVG-elements on a page then only one gets drawn.

**Why**
SVG-elements and childelements do not have the uniqueNumber property.
When added to the draw queue (drawQueue[el.uniqueNumber] = el;) those elements are added with the key 'undefined'.

Since the key is unique there will only be one SVG-element in the draw queue.

**Solution**
Since we want the drawQueue to consist of unique elements so that no unesesary drawing is done we can use a Set() to store the elements.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set

Thanks nuxodin for maintaining this project.