### PR TITLE
Test example + fix for calc bug when using style.setProperty

### DIFF
--- a/ie11CustomProperties.js
+++ b/ie11CustomProperties.js
@@ -598,10 +598,12 @@
 			if (!el.ieCP_setters) el.ieCP_setters = {};
 			el.ieCP_setters[property] = 1;
 			drawTree(el);
-			if (el === document.documentElement) redrawStyleSheets(); // make this inside drawTree?
 		}
 		property = '-ie-'+(prio==='important'?'❗':'') + property.substr(2);
 		this.cssText += '; ' + property + ':' + value + ';';
+		if (this.owningElement && this.owningElement === document.documentElement) {
+			redrawStyleSheets();
+		}
 		//this[property] = value;
 	};
 

--- a/tests.html
+++ b/tests.html
@@ -421,6 +421,35 @@ This to make it possible to show the original style on hover.
         </div>
     </div>
 
+    <div id="dynamicCalc">
+      setProperty on root, containing calc - should have a border-top of
+      <span class="border-top">10px</span>.
+      <div class="code">
+        <script>
+          var dynamicCalc = document.querySelector('#dynamicCalc'),
+            dynamicCalcSpan = dynamicCalc.querySelector('.border-top'),
+            currentDynamicCalcValue = 10;
+          dynamicCalc.addEventListener('click', function() {
+            currentDynamicCalcValue = currentDynamicCalcValue == 10 ? 50 : 10;
+            document.documentElement.style.setProperty(
+              '--dynamic-value',
+              currentDynamicCalcValue + 'px'
+            );
+            dynamicCalcSpan.innerText = currentDynamicCalcValue + 5 + 'px';
+          });
+        </script>
+        <pre>
+          #dynamicCalc {
+            border-top: calc(var(--dynamic-value, 10px) + 5px) solid red;
+          }
+          #dynamicCalc {
+            background-color: var(--green);
+          }
+        </pre>
+      </div>
+    </div>
+
+
 </div>
 
 <script>

--- a/tests.html
+++ b/tests.html
@@ -423,7 +423,7 @@ This to make it possible to show the original style on hover.
 
     <div id="dynamicCalc">
       setProperty on root, containing calc - should have a border-top of
-      <span class="border-top">10px</span>.
+      <span class="border-top">10px</span>. (Please click on me)
       <div class="code">
         <script>
           var dynamicCalc = document.querySelector('#dynamicCalc'),


### PR DESCRIPTION
Hello, @nuxodin.

This is a test for the bug where CSS variables containing `calc` which are set using `style.setProperty` get stuck one step behind in calculations (when they are updated, the calculated value is processed using the old value). The test replicates the issue in IE11 (version 11.592.18362.0).

To test, click multiple times on the block. The border-top width should update, but it gets stuck one step behind.

Thank you!