### PR TITLE
Preserve media attributes when rewriting linked stylesheets

### DIFF
--- a/ie11CustomProperties.js
+++ b/ie11CustomProperties.js
@@ -114,6 +114,7 @@
 			newCss = relToAbs(el.href, newCss);
 			el.disabled = true;
 			var style = document.createElement('style');
+			if (el.media) style.setAttribute('media', el.media);
 			el.parentNode.insertBefore(style, el);
 			activateStyleElement(style, newCss);
 		});


### PR DESCRIPTION
This fix preserves `media` attributes, so that print styles do not override screen styles:

Old:

```html
<link rel="stylesheet" href="../css/screen.css">
<style>
// Generated ie11CustomProperties styles (for screen)
</style>

<link rel="stylesheet" href="../css/print.css" media="print">
<style>
// Generated ie11CustomProperties styles (for print)
// as the style element has no media attribute
// these styles display all the time
// and trump the styles in screen.css
</style>
```
New:

```html
<link rel="stylesheet" href="../css/screen.css">
<style>
// Generated ie11CustomProperties styles (for screen)
</style>

<link rel="stylesheet" href="../css/print.css" media="print">
<style media="print">
// Generated ie11CustomProperties styles (for print)
// these styles only display in the browser print preview
</style>
```