### PR TITLE
Add :visited and :link pseudo classes for hyperlinks.

### DIFF
--- a/ie11CustomProperties.js
+++ b/ie11CustomProperties.js
@@ -105,7 +105,7 @@
 	const regRuleIEGetters = /-ieVar-([^:]+):/g
 	const regRuleIESetters = /-ie-([^};]+)/g
 	//const regHasVar = /var\(/;
-	const regPseudos = /:(hover|active|focus|target|:before|:after|:first-letter|:first-line)/;
+	const regPseudos = /:(hover|active|focus|target|visited|link|:before|:after|:first-letter|:first-line)/;
 
 	onElement('link[rel="stylesheet"]', function (el) {
 		fetchCss(el.href, function (css) {


### PR DESCRIPTION
.iecp classes were not added for CSS rules using :visited or :link pseudo classes and other styles end up being more specific. With the pseudo classes added to the regex the styles are applied as expected.