### PR TITLE
Matching based on a data attributes rather than classes

### DIFF
--- a/ie11CustomProperties.js
+++ b/ie11CustomProperties.js
@@ -408,7 +408,7 @@
 	function _drawElement(el) {
 		if (!el.ieCP_unique) { // use el.uniqueNumber? but needs class for the css-selector => test performance
 			el.ieCP_unique = ++uniqueCounter;
-			el.classList.add('iecp-u' + el.ieCP_unique);
+			el.setAttribute('data-iecp', el.ieCP_unique);
 		}
 		var style = getComputedStyle(el);
 		let css = '';
@@ -430,7 +430,7 @@
 
 					//let selector = item.selector.replace(/>? \.[^ ]+/, ' ', item.selector); // todo: try to equalize specificity
 					let selector = item.selector;
-					css += selector + '.iecp-u' + el.ieCP_unique + item.pseudo + '{' + prop + ':' + value + '}\n';
+					css += selector + '[data-iecp="' + el.ieCP_unique + '"]'  + item.pseudo + '{' + prop + ':' + value + '}\n';
 				}
 			}
 		}


### PR DESCRIPTION
Addresses issue #43.

Problem:

Components (React or otherwise) will likely mutate class names as state changes. When they do, the custom appended classnames may be removed unless the framework updating the class attribute toggles classes rather than replacing them. React for example will replace the class attribute, causing the manually added ones to be removed.

Resolution:

Set data attributes and use those to match against. The data attributes are far more unlikely to be tampered with by the user.

I've validated that in situations where I was seeing classes be blown away by components with mutating classnames, this is now resolved with this fix.