### PR TITLE
Use style `sheet`, remove URL rewriting

### DIFF
--- a/ie11CustomProperties.js
+++ b/ie11CustomProperties.js
@@ -113,28 +113,25 @@
 	//const regHasVar = /var\(/;
 	var regPseudos = /:(hover|active|focus|target|visited|link|:before|:after|:first-letter|:first-line)/;
 
-	onElement('link[rel="stylesheet"]', function (el) {
-		fetchCss(el.href, function (css) {
-			var newCss = rewriteCss(css);
-			if (css === newCss) return;
-			newCss = relToAbs(el.href, newCss);
-			el.disabled = true;
-			var style = document.createElement('style');
-			if (el.media) style.setAttribute('media', el.media);
-			el.parentNode.insertBefore(style, el);
-			activateStyleElement(style, newCss);
-		});
-	});
-
 	function foundStyle(el){
 		if (el.ieCP_polyfilled) return;
 		if (el.ieCP_elementSheet) return;
+		if (!el.sheet) return;
+		if (el.href) {
+			return fetchCss(el.href, function (css) {
+				var newCss = rewriteCss(css);
+				if (css === newCss) return;
+				activateStyleElement(el, newCss);
+			});
+		}
+
 		var css = el.innerHTML;
 		var newCss = rewriteCss(css);
 		if (css === newCss) return;
 		activateStyleElement(el, newCss);
 	}
 	onElement('style', foundStyle);
+	onElement('link[rel="stylesheet"]', foundStyle);
 	// immediate, to pass w3c-tests, bud its a bad idea
 	// addEventListener('DOMNodeInserted',function(e){ e.target.tagName === 'STYLE' && foundStyle(e.target); });
 
@@ -147,15 +144,6 @@
 		if (found.getters) addGetterElement(el, found.getters, '%styleAttr');
 		if (found.setters) addSetterElement(el, found.setters);
 	});
-
-	function relToAbs(base, css) {
-		return css.replace(/url\(([^)]+)\)/g, function($0, $1){
-			$1 = $1.trim().replace(/(^['"]|['"]$)/g,'');
-			if ($1.match(/^([a-z]+:|\/)/)) return $0;
-			base = base.replace(/\?.*/,'');
-			return 'url('+ base + './../' + $1 +')';
-		});
-	}
 
 	// ie has a bug, where unknown properties at pseudo-selectors are computed at the element
 	// #el::after { -content:'x'; } => getComputedStyle(el)['-content'] == 'x'
@@ -229,7 +217,7 @@
 		return {getters:getters, setters:setters};
 	}
 	function activateStyleElement(style, css) {
-		style.innerHTML = css;
+		style.sheet.cssText = css;
 		style.ieCP_polyfilled = true;
 		var rules = style.sheet.rules, i=0, rule; // cssRules = CSSRuleList, rules = MSCSSRuleList
 		while (rule = rules[i++]) {


### PR DESCRIPTION
This PR changes how `<style>` and `<link rel="stylesheet" />` stylesheets are updated in IE11. Instead of rewriting `<link rel="stylesheet" />` tags as `<style>` tags, the [CSSOM StyleSheet](https://developer.mozilla.org/en-US/docs/Web/API/StyleSheet) text is rewritten.

#### Benefits

- Uses `cssText` instead of `createElement` and `innerHTML`, reducing the number of DOM modifications.
- Preserves linked stylesheet href, removing the need to rewrite internal URLs.
- Reduces the overall script size and code complexity.