### PR TITLE
Fix IE11 getPropertyValue undefined argument issue

### DIFF
--- a/ie11CustomProperties.js
+++ b/ie11CustomProperties.js
@@ -514,7 +514,7 @@
 
 	var oldGetP = StyleProto.getPropertyValue;
 	StyleProto.getPropertyValue = function (property) {
-		if (!property) return '';
+		if (arguments.length && !property) return '';
 
 		this.lastPropertyServedBy = false;
 		property = property.trim();

--- a/ie11CustomProperties.js
+++ b/ie11CustomProperties.js
@@ -514,6 +514,8 @@
 
 	var oldGetP = StyleProto.getPropertyValue;
 	StyleProto.getPropertyValue = function (property) {
+		if (!property) return '';
+
 		this.lastPropertyServedBy = false;
 		property = property.trim();
 


### PR DESCRIPTION
This is a fix for getPropertyValue when called with undefined or falsy value as main argument #76

In IE11 when getPropertyValue is called with no arguments the function throws an error, however when called with falsy values it returns an empty string.