### PR TITLE
fix: use escape instead of hexadecimal code for script integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Used on about 11'000 [Live Websites](https://publicwww.com/websites/ie11CustomPr
 ## Usage
 You only want IE11 to load the polyfill, use this snippet in the head of your html file, it just works:
 ```html
-<script>window.MSInputMethodContext && document.documentMode && document.write('<script src="https://cdn.jsdelivr.net/gh/nuxodin/ie11CustomProperties@4.1.0/ie11CustomProperties.min.js"><\x2fscript>');</script>
+<script>window.MSInputMethodContext && document.documentMode && document.write('<script src="https://cdn.jsdelivr.net/gh/nuxodin/ie11CustomProperties@4.1.0/ie11CustomProperties.min.js"><\/script>');</script>
 ```
 
 ## Help wanted!

--- a/demo.html
+++ b/demo.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>CSS Custom Properties IE11 Demo</title>
-  <script>window.MSInputMethodContext && document.documentMode && document.write('<script src="./ie11CustomProperties.js"><\x2fscript>');</script>
+  <script>window.MSInputMethodContext && document.documentMode && document.write('<script src="./ie11CustomProperties.js"><\/script>');</script>
 <body>
 <a href="https://github.com/nuxodin/ie11CustomProperties" style="flex-basis:100%; max-width:none; padding:.5em">back to project</a>
 <style>

--- a/tests/performance.html
+++ b/tests/performance.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>CSS Custom Properties IE11 Test</title>
-    <script>window.MSInputMethodContext && document.documentMode && document.write('<script src="../ie11CustomProperties.js"><\x2fscript>');</script>
+    <script>window.MSInputMethodContext && document.documentMode && document.write('<script src="../ie11CustomProperties.js"><\/script>');</script>
 <body>
 <a href="https://github.com/nuxodin/ie11CustomProperties" style="flex-basis:100%; max-width:none; padding:.5em">back to project</a>
 

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>CSS Custom Properties IE11 Test</title>
-    <script>window.MSInputMethodContext && document.documentMode && document.write('<script src="../ie11CustomProperties.js"><\x2fscript>');</script>
+    <script>window.MSInputMethodContext && document.documentMode && document.write('<script src="../ie11CustomProperties.js"><\/script>');</script>
 <body>
 <a href="https://github.com/nuxodin/ie11CustomProperties" style="flex-basis:100%; max-width:none; padding:.5em">back to project</a>
 


### PR DESCRIPTION
Hello,
After some discussion with coworkers asking if `\x2f` was a typo in documentation, we agree to fix it with an escaped slash.
I have this article as reference for this choice https://mathiasbynens.be/notes/etago#recommendations