### PR TITLE
added ie-ignore attribute check

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ vars in @import is not supported at the moment
 #### !important
 There are problems with !important. I need a minimal, reproducible testcase on https://jsbin.com/ 
 
+#### Stylesheets outside the domain
+Conversions will not work across domains, add *ie-ignore* tag to the link element so the polyfill ignores this sheet without crashing the site.
 
 ## Tests
 [See the tests](https://rawcdn.githack.com/nuxodin/ie11CustomProperties/6c465d21a8c043a45cba939995bb434966048377/tests.html)  

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ vars in @import is not supported at the moment
 There are problems with !important. I need a minimal, reproducible testcase on https://jsbin.com/ 
 
 #### Stylesheets outside the domain
-Conversions will not work across domains, add *ie-ignore* tag to the link element so the polyfill ignores this sheet without crashing the site.
+If you'd prefer the polyfill to ignore (not run) on a particular stylesheet add the  *iecp-ignore* tag to the link element.
 
 ## Tests
 [See the tests](https://rawcdn.githack.com/nuxodin/ie11CustomProperties/6c465d21a8c043a45cba939995bb434966048377/tests.html)  

--- a/ie11CustomProperties.js
+++ b/ie11CustomProperties.js
@@ -130,8 +130,8 @@
 		if (css === newCss) return;
 		activateStyleElement(el, newCss);
 	}
-	onElement('style:not([ie-ignore])', foundStyle);
-	onElement('link[rel=stylesheet]:not([ie-ignore])', foundStyle);
+	onElement('style:not([iecp-ignore])', foundStyle);
+	onElement('link[rel=stylesheet]:not([iecp-ignore])', foundStyle);
 	// immediate, to pass w3c-tests, bud its a bad idea
 	// addEventListener('DOMNodeInserted',function(e){ e.target.tagName === 'STYLE' && foundStyle(e.target); });
 
@@ -305,7 +305,7 @@
 		},
 	};
 	function selectorAddPseudoListeners(selector){
-		// ie11 has the strange behavoir, that groups of selectors are individual rules, but starting with the full selector:
+		// ie11 has the strange behavior, that groups of selectors are individual rules, but starting with the full selector:
 		// td, th, button { color:red } results in this rules:
 		// "td, th, button" | "th, th" | "th"
 		selector = selector.split(',')[0];

--- a/ie11CustomProperties.js
+++ b/ie11CustomProperties.js
@@ -130,8 +130,8 @@
 		if (css === newCss) return;
 		activateStyleElement(el, newCss);
 	}
-	onElement('style', foundStyle);
-	onElement('link[rel="stylesheet"]', foundStyle);
+	onElement('style:not([ie-ignore])', foundStyle);
+	onElement('link[rel=stylesheet]:not([ie-ignore])', foundStyle);
 	// immediate, to pass w3c-tests, bud its a bad idea
 	// addEventListener('DOMNodeInserted',function(e){ e.target.tagName === 'STYLE' && foundStyle(e.target); });
 


### PR DESCRIPTION
I stumbled across this polyfill while working with a website that uses both local and [cdn-provided stylesheet(s)](//cdn.jsdelivr.net/npm/xeicon@2.3.3/xeicon.min.css). I did not need to polyfill the one provided outside the domain as it does not use variable features.

by adding the "ie-ignore" tag, one can stop the polyfill from crashing the site itself - while processing the local css.
as many websites use multiple outside libraries, this small change will greatly expand the usage of this library.